### PR TITLE
docs: migrate URLs from `docker.pkg.github.com` to `ghcr.io`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@ GridDB Dockerfile sample has been confirmed to work in the following environment
 ## 1. GridDB Server
 
 ### (CentOS7)
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb:0.3
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb:0.3
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb:0.3
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb:0.3
 ### (Ubuntu:bionic)
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-bionic:0.3
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-bionic:0.3
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-bionic:0.3
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-bionic:0.3
 ### (openSUSE leap 15)
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-opensuse-15:0.3
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-opensuse-15:0.3
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-opensuse-15:0.3
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-opensuse-15:0.3
 
 ## 2. SQLWorkbench/J on Java Env.
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/python-db-api:0.2
-    > docker run -it docker.pkg.github.com/knonomura/griddb-docker/python-db-api:0.2 bash
+    > docker pull ghcr.io/knonomura/griddb-docker/python-db-api:0.2
+    > docker run -it ghcr.io/knonomura/griddb-docker/python-db-api:0.2 bash
 
 Note. Please download after confirming the license of SQL Workbench/J.  
 "This software is licensed under a modified version of the Apache License, Version 2.0 http://sql-workbench.eu/manual/license.html that restricts the use of the software for certain organizations."
@@ -60,27 +60,27 @@ Please refer to [SQL Samples](SQLSamples.md).
 ## 3. JayDeBeApi(DB-API) on Python Env.
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/python-db-api:0.2
-    > docker run -it docker.pkg.github.com/knonomura/griddb-docker/python-db-api:0.2 bash
+    > docker pull ghcr.io/knonomura/griddb-docker/python-db-api:0.2
+    > docker run -it ghcr.io/knonomura/griddb-docker/python-db-api:0.2 bash
     # python DBAPISample.py
 
 ## 4. WebAPI
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/webapi:0.2
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/webapi:0.2
+    > docker pull ghcr.io/knonomura/griddb-docker/webapi:0.2
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/webapi:0.2
     > docker exec -it <CONTAINER ID for webapi IMAGE> bash
     # ./sample.sh
     {"count":1}{"columns":[...
     > docker stop <CONTAINER ID for webapi IMAGE>
-    
+
 # Using NoSQL Interface with GridDB V4.6CE
 
 ## Java Client
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/java-client:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/java-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/java-client:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/java-client:0.1
     ...
     Person:  name=name02 status=false count=2 lob=[65, 66, 67, 68, 69, 70, 71, 72, 73, 74]
     ...
@@ -88,96 +88,96 @@ Please run GridDB Server in advance.
 ## C Client
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/c-client:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/c-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/c-client:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/c-client:0.1
     Person: name=name02 status=false count=2 lob=[65, 66, 67, 68, 69, 70, 71, 72, 73, 74]
 
 ## Python Client
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/python-client:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/python-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/python-client:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/python-client:0.1
     Person: name=name02 status=False count=2 lob=[65, 66, 67, 68, 69, 70, 71, 72, 73, 74]
 
 ## Node.JS Client
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/nodejs-client:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/nodejs-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/nodejs-client:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/nodejs-client:0.1
     [ 'name01', false, 1, <Buffer 41 42 43 44 45 46 47 48 49 4a> ]
 
 ## Go Client
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/go-client:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/go-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/go-client:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/go-client:0.1
     Person: name= name02  status= false  count= 2  lob= [65 66 67 68 69 70 71 72 73 74]
 
 ## PHP Client
 Please run GridDB Server in advance.
 
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/php-client:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/php-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/php-client:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/php-client:0.1
     Person: name=name02 status=false count=2 lob=ABCDEFGHIJ
 
 
 # Using NoSQL Interface with GridDB V4.3CE
 
 ## Java Client
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/java-client:0.1
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/java-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/java-client:0.1
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/java-client:0.1
     ...
     Person:  name=name02 status=false count=2 lob=[65, 66, 67, 68, 69, 70, 71, 72, 73, 74]
     ...
     > docker stop <CONTAINER ID for griddb-nosql IMAGE>
 
 ## C Client
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/c-client:0.1
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/c-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/c-client:0.1
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/c-client:0.1
     Person: name=name02 status=false count=2 lob=[65, 66, 67, 68, 69, 70, 71, 72, 73, 74]
     > docker stop <CONTAINER ID for griddb-nosql IMAGE>
 
 ## Python Client
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/python-client:0.1
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/python-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/python-client:0.1
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/python-client:0.1
     Person: name=name02 status=False count=2 lob=[65, 66, 67, 68, 69, 70, 71, 72, 73, 74]
     > docker stop <CONTAINER ID for griddb-nosql IMAGE>
 
 ## Node.JS Client
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/nodejs-client:0.1
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/nodejs-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/nodejs-client:0.1
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/nodejs-client:0.1
     [ 'name01', false, 1, <Buffer 41 42 43 44 45 46 47 48 49 4a> ]
     > docker stop <CONTAINER ID for griddb-nosql IMAGE>
 
 ## Go Client
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/go-client:0.1
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/go-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/go-client:0.1
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/go-client:0.1
     Person: name= name02  status= false  count= 2  lob= [65 66 67 68 69 70 71 72 73 74]
     > docker stop <CONTAINER ID for griddb-nosql IMAGE>
 
 ## PHP Client
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/php-client:0.1
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker run --rm docker.pkg.github.com/knonomura/griddb-docker/php-client:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/php-client:0.1
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker run --rm ghcr.io/knonomura/griddb-docker/php-client:0.1
     Person: name=name02 status=false count=2 lob=ABCDEFGHIJ
     > docker stop <CONTAINER ID for griddb-nosql IMAGE>
 
 ## WebAPI
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker pull docker.pkg.github.com/knonomura/griddb-docker/webapi:0.1
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/griddb-nosql:0.1
-    > docker run --rm -d docker.pkg.github.com/knonomura/griddb-docker/webapi:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker pull ghcr.io/knonomura/griddb-docker/webapi:0.1
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/griddb-nosql:0.1
+    > docker run --rm -d ghcr.io/knonomura/griddb-docker/webapi:0.1
     > docker exec -it <CONTAINER ID for webapi IMAGE> bash
     # curl  https://raw.githubusercontent.com/knonomura/griddb-docker/master/webapi/sample.sh -o sample.sh
     # ./sample.sh


### PR DESCRIPTION
## Summary

Update README URLs to use the newer `ghcr.io` instead of `docker.pkg.github.com`

## Details

- Per https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry and https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry, GitHub's Docker Registry under `docker.pkg.github.com` was replaced by its Container Registry at `ghcr.io`
  - all the GitHub Packages all say to use `ghcr.io` as well; for instance https://github.com/knonomura/griddb-docker/pkgs/container/griddb-docker%2Fpython-client shows `docker pull ghcr.io/knonomura/griddb-docker/python-client:0.1`
  - so update all URLs to use `ghcr.io` now

- without this change, I was getting 403 errors trying to pull any of the images:
```sh
❯ podman pull docker.pkg.github.com/knonomura/griddb-docker/python-client:0.1
Trying to pull docker.pkg.github.com/knonomura/griddb-docker/python-client:0.1...
Error: initializing source docker://docker.pkg.github.com/knonomura/griddb-docker/python-client:0.1: reading manifest 0.1 in docker.pkg.github.com/knonomura/griddb-docker/python-client: denied
```
- whereas with `ghcr.io` I had no errors:
```sh
❯ podman pull ghcr.io/knonomura/griddb-docker/python-client:0.1
Trying to pull ghcr.io/knonomura/griddb-docker/python-client:0.1...
Getting image source signatures
Copying blob sha256:963cd0d2f1c4fa5aeb3a4fddd06450b9256cfb8cb75c28ff5d022f2ff4e29b79
Copying blob sha256:b2e87f21e84290f3734dd31f71a9cb52f29e02d50ec5ff03dd33fcce05d7d115
Copying blob sha256:ab5ef0e5819490abe86106fd9f4381123e37a03e80e650be39f7938d30ecb530
Copying blob sha256:db93fe3d3cf751c9d152bed86d39e11d433ab30d70f14c1addc43f6d1359300a
Copying blob sha256:dde0760d8240f950d74c9b066410ba6fb69493074f57ab213f0dd74ddd15f699
Copying blob sha256:e7b05ba5389a3e4c0de98ae55f0d8a5698bd184e990ec9af513382f9555ec3b8
Copying blob sha256:b083952edafdf330204b35a1fc9c752fdc1b7c6587bd7ec42c72732cbb29f113
Copying blob sha256:d6bf0a76df283e0efa04968610724079cf8de536d6da4a1cefd9deb24b09bbed
Copying config sha256:95c21a66c29bac6c0def09befac436f33d23a639d2d6973c22ed682c5c148550
Writing manifest to image destination
95c21a66c29bac6c0def09befac436f33d23a639d2d6973c22ed682c5c148550
```